### PR TITLE
fix validation failed error on ubuntu 24.04

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,6 @@
   ansible.builtin.template:
     src: etc/rsyslog.conf.j2
     dest: /etc/rsyslog.conf
-    validate: 'rsyslogd -N1 -f %s'
     owner: root
     group: root
     mode: 0440
@@ -68,6 +67,17 @@
     - rsyslog
     - rsyslog-configuration
     - rsyslog-configuration-rsyslog
+
+- name: manually validate rsyslog config
+  ansible.builtin.command: rsyslogd -N1 -f /etc/rsyslog.conf
+  become: true
+  register: validate_result
+  changed_when: false
+  failed_when: validate_result.rc != 0
+  tags:
+    - configuration
+    - rsyslog
+    - rsyslog-validation
 
 - name: start and enable service
   ansible.builtin.service:


### PR DESCRIPTION
in ubuntu 24.04 validation always fails due to hardened permissions
```
TASK [ansible-rsyslog : update global configuration file] ************************************************************************************************************************************************************
fatal: [10.150.31.195]: FAILED! => {"changed": false, "checksum": "1b47df8916644562862da9b8d611378b7ac35d15", "exit_status": 1, "msg": "failed to validate", "stderr": "rsyslogd: version 8.2312.0, config validation run (level 1), master config /tmp/ansible-tmp-1748055647.6420233-9492-40362063032503/.source.conf\nrsyslogd: could not open config file '/tmp/ansible-tmp-1748055647.6420233-9492-40362063032503/.source.conf': Permission denied [v8.2312.0 try https://www.rsyslog.com/e/2104 ]\nrsyslogd: run failed with error -2104 (see rsyslog.h or try https://www.rsyslog.com/e/2104 to learn what that number means)\n", "stderr_lines": ["rsyslogd: version 8.2312.0, config validation run (level 1), master config /tmp/ansible-tmp-1748055647.6420233-9492-40362063032503/.source.conf", "rsyslogd: could not open config file '/tmp/ansible-tmp-1748055647.6420233-9492-40362063032503/.source.conf': Permission denied [v8.2312.0 try https://www.rsyslog.com/e/2104 ]", "rsyslogd: run failed with error -2104 (see rsyslog.h or try https://www.rsyslog.com/e/2104 to learn what that number means)"], "stdout": "", "stdout_lines": []}
```
`become: true` doesn't help

have to do validation step separately